### PR TITLE
Bringing Windows environment up to speed

### DIFF
--- a/external/cJSON/CMakeLists.txt
+++ b/external/cJSON/CMakeLists.txt
@@ -5,3 +5,4 @@ add_library(cjson SHARED
         cJSON.h
         )
 target_include_directories(cjson PUBLIC .)
+set_target_properties(cjson PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)

--- a/external/oscpack/CMakeLists.txt
+++ b/external/oscpack/CMakeLists.txt
@@ -10,7 +10,7 @@ else (WIN32)
     set(IpSystemTypePath ip/posix)
 endif (WIN32)
 
-add_library(oscpack SHARED
+add_library(oscpack STATIC
 
         ip/IpEndpointName.h
         ip/IpEndpointName.cpp

--- a/external/oscpack/CMakeLists.txt
+++ b/external/oscpack/CMakeLists.txt
@@ -10,7 +10,7 @@ else (WIN32)
     set(IpSystemTypePath ip/posix)
 endif (WIN32)
 
-add_library(oscpack STATIC
+add_library(oscpack SHARED
 
         ip/IpEndpointName.h
         ip/IpEndpointName.cpp
@@ -45,6 +45,7 @@ target_include_directories(oscpack PUBLIC zeroconf)
 target_include_directories(oscpack PRIVATE .)
 
 target_link_libraries(oscpack ${OSCPACKLIBS})
+set_target_properties(oscpack PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 
 if (MSVC)
     # Force to always compile with W4

--- a/external/oscpack/osc/OscTypes.h
+++ b/external/oscpack/osc/OscTypes.h
@@ -40,6 +40,16 @@
 
 namespace osc{
 
+#ifdef _MSC_VER
+#   ifdef oscpack_EXPORTS
+#       define OSCPACK_API __declspec(dllexport)
+#	else
+#       define OSCPACK_API __declspec(dllimport)
+#   endif
+#else
+#   define OSCPACK_API
+#endif
+
 // basic types
 
 #if defined(__BORLANDC__) || defined(_MSC_VER)
@@ -139,7 +149,7 @@ struct BundleInitiator{
     uint64 timeTag;
 };
 
-extern BundleInitiator BeginBundleImmediate;
+extern OSCPACK_API BundleInitiator BeginBundleImmediate;
 
 inline BundleInitiator BeginBundle( uint64 timeTag=1 )
 {
@@ -150,7 +160,7 @@ inline BundleInitiator BeginBundle( uint64 timeTag=1 )
 struct BundleTerminator{
 };
 
-extern BundleTerminator EndBundle;
+extern OSCPACK_API BundleTerminator EndBundle;
 
 struct BeginMessage{
     explicit BeginMessage( const char *addressPattern_ ) : addressPattern( addressPattern_ ) {}
@@ -160,7 +170,7 @@ struct BeginMessage{
 struct MessageTerminator{
 };
 
-extern MessageTerminator EndMessage;
+extern OSCPACK_API MessageTerminator EndMessage;
 
 
 // osc specific types. they are defined as structs so they can be used
@@ -169,16 +179,16 @@ extern MessageTerminator EndMessage;
 struct NilType{
 };
 
-extern NilType OscNil;
+extern OSCPACK_API NilType OscNil;
 
 #ifndef _OBJC_OBJC_H_
-extern NilType Nil; // Objective-C defines Nil. so our Nil is deprecated. use OscNil instead
+extern OSCPACK_API NilType Nil; // Objective-C defines Nil. so our Nil is deprecated. use OscNil instead
 #endif
 
 struct InfinitumType{
 };
 
-extern InfinitumType Infinitum;
+extern OSCPACK_API InfinitumType Infinitum;
 
 struct RgbaColor{
     RgbaColor() {}
@@ -227,12 +237,12 @@ struct Blob{
 struct ArrayInitiator{
 };
 
-extern ArrayInitiator BeginArray;
+extern OSCPACK_API ArrayInitiator BeginArray;
 
 struct ArrayTerminator{
 };
 
-extern ArrayTerminator EndArray;
+extern OSCPACK_API ArrayTerminator EndArray;
 
 } // namespace osc
 

--- a/external/portaudio/CMakeLists.txt
+++ b/external/portaudio/CMakeLists.txt
@@ -6,3 +6,4 @@ add_library(portaudio SHARED
         pa_ringbuffer.h
         )
 target_include_directories(portaudio PUBLIC .)
+set_target_properties(portaudio PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)

--- a/external/rtmidi/CMakeLists.txt
+++ b/external/rtmidi/CMakeLists.txt
@@ -24,4 +24,6 @@ elseif (UNIX)
     target_link_libraries(rtmidi ${ALSA_LIBRARIES})
 endif (APPLE)
 
+set_target_properties(rtmidi PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
+
 target_include_directories(rtmidi PUBLIC .)

--- a/mec-api/CMakeLists.txt
+++ b/mec-api/CMakeLists.txt
@@ -67,6 +67,6 @@ if(NOT WIN32)
 endif()
 
 target_link_libraries(mec-api mec-utils ${MEC_DEVICE_LIBS}  mec-kontrol-api cjson oscpack rtmidi)
-
+set_target_properties(mec-api PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 add_subdirectory(tests)
 

--- a/mec-api/devices/mec_osct3d.cpp
+++ b/mec-api/devices/mec_osct3d.cpp
@@ -6,6 +6,7 @@
 #include <osc/OscPacketListener.h>
 #include <ip/UdpSocket.h>
 
+#include <algorithm>
 
 #include "mec_log.h"
 #include "../mec_voice.h"

--- a/mec-api/mec_surface.cpp
+++ b/mec-api/mec_surface.cpp
@@ -8,6 +8,7 @@
 
 #include "mec_log.h"
 
+#include <algorithm>
 
 namespace mec {
 

--- a/mec-app/mec_app.cpp
+++ b/mec-app/mec_app.cpp
@@ -1,4 +1,17 @@
+#ifndef _WIN32
+
 #include <unistd.h>
+
+#else
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+inline void usleep(unsigned int u) { Sleep(u / 1000); }
+inline void sleep(unsigned int seconds) { Sleep(seconds * 1000); }
+
+#endif
+
 #include <signal.h>
 #include <string.h>
 
@@ -74,9 +87,9 @@ int main(int ac, char **av) {
     sigemptyset(&s.sa_mask);
     s.sa_flags = 0;
     sigaction(SIGINT, &s, NULL);
-#endif
     // Restore the old signal mask only for this thread.
     pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+#endif
 
     {
         std::unique_lock<std::mutex> lock(waitMtx);

--- a/mec-app/mecapi_cmd.cpp
+++ b/mec-app/mecapi_cmd.cpp
@@ -1,7 +1,22 @@
-#include <unistd.h>
-#include <string.h>
+#ifndef _MSC_VER
 
+#include <unistd.h>
 #include <pthread.h>
+
+#else
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+inline void sleep(unsigned int seconds) { Sleep(seconds * 1000); }
+
+inline void pthread_exit(void *value_ptr)
+{
+    ExitProcess(*(int*)value_ptr);
+}
+
+#endif
+#include <string.h>
 
 #include <osc/OscOutboundPacketStream.h>
 #include <ip/UdpSocket.h>

--- a/mec-kontrol/api/CMakeLists.txt
+++ b/mec-kontrol/api/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories(
 )
 
 add_library(mec-kontrol-api SHARED ${KONTROL_API_SRC})
-
+set_target_properties(mec-kontrol-api PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 target_link_libraries(mec-kontrol-api mec-utils oscpack portaudio cjson)
 
 # add_subdirectory(tests)

--- a/mec-kontrol/api/ChangeSource.h
+++ b/mec-kontrol/api/ChangeSource.h
@@ -29,9 +29,19 @@ private:
 bool operator==(const ChangeSource& a,const ChangeSource& b);
 bool operator!=(const ChangeSource &a, const ChangeSource &b);
 
-extern const  ChangeSource CS_LOCAL;
-extern const  ChangeSource CS_MIDI;
-extern const  ChangeSource CS_PRESET;
+#ifdef _MSC_VER
+#   ifdef mec_kontrol_api_EXPORTS
+#       define MEC_KONTROL_API __declspec(dllexport)
+#	else
+#       define MEC_KONTROL_API __declspec(dllimport)
+#   endif
+#else
+#   define MEC_KONTROL_API
+#endif
+
+extern MEC_KONTROL_API const  ChangeSource CS_LOCAL;
+extern MEC_KONTROL_API const  ChangeSource CS_MIDI;
+extern MEC_KONTROL_API const  ChangeSource CS_PRESET;
 
 } // namespace
 

--- a/mec-kontrol/api/Parameter.cpp
+++ b/mec-kontrol/api/Parameter.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <cmath>
+#include <algorithm>
 #include <mec_log.h>
 
 namespace Kontrol {

--- a/mec-kontrol/pd/kontrolmodule/KontrolModule.cpp
+++ b/mec-kontrol/pd/kontrolmodule/KontrolModule.cpp
@@ -19,7 +19,7 @@ typedef struct _KontrolModule {
 extern "C" {
 void KontrolModule_free(t_KontrolModule *);
 void *KontrolModule_new(t_symbol *name, t_symbol *type);
-void KontrolModule_setup(void);
+EXTERN void KontrolModule_setup(void);
 void KontrolModule_loaddefinitions(t_KontrolModule *x, t_symbol *defs);
 }
 // puredata methods implementation - start

--- a/mec-kontrol/pd/kontrolrack/CMakeLists.txt
+++ b/mec-kontrol/pd/kontrolrack/CMakeLists.txt
@@ -5,6 +5,8 @@ project(KontrolRack)
 
 set(KONTROL_HOST_SRC
         KontrolRack.cpp
+        dirent_win.cpp
+        dirent_win.h
         devices/KontrolDevice.cpp
         devices/Organelle.cpp
         )

--- a/mec-kontrol/pd/kontrolrack/CMakeLists.txt
+++ b/mec-kontrol/pd/kontrolrack/CMakeLists.txt
@@ -38,8 +38,10 @@ elseif (${WIN32})
 endif ()
 
 # Removes some warning for Microsoft Visual C.
-if (${MSVC})
+if (${WIN32})
     target_compile_definitions(${PROJECT_NAME} PRIVATE PD_INTERNAL)
-    set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS "/D_CRT_SECURE_NO_WARNINGS /wd4091 /wd4996")
+    if (${MSVC})
+        set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS "/D_CRT_SECURE_NO_WARNINGS /wd4091 /wd4996")
+    endif ()
 endif ()
 

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -3,6 +3,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <clocale>
 
 /*****

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -1,6 +1,10 @@
 #include "KontrolRack.h"
 
-#include <dirent.h>
+#ifndef _WIN32
+#   include <dirent.h>
+#else
+#   include "dirent_win.h"
+#endif
 #include <sys/stat.h>
 
 #include <algorithm>
@@ -445,7 +449,9 @@ void KontrolRack_loadresources(t_KontrolRack *x) {
                     post("KontrolRack::module found: %s", namelist[i]->d_name);
                 }
             }
+            free(namelist[i]);
         }
+        free(namelist);
     }
 }
 

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -113,7 +113,7 @@ void *KontrolRack_new(t_floatarg serverport, t_floatarg clientport) {
     return (void *) x;
 }
 
-void KontrolRack_setup(void) {
+EXTERN void KontrolRack_setup(void) {
     KontrolRack_class = class_new(gensym("KontrolRack"),
                                   (t_newmethod) KontrolRack_new,
                                   (t_method) KontrolRack_free,

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -32,7 +32,7 @@ extern "C" {
 void KontrolRack_tick(t_KontrolRack *x);
 void KontrolRack_free(t_KontrolRack *);
 void *KontrolRack_new(t_floatarg,t_floatarg);
-void KontrolRack_setup(void);
+EXTERN void KontrolRack_setup(void);
 
 
 void KontrolRack_listen(t_KontrolRack *x, t_floatarg f);

--- a/mec-kontrol/pd/kontrolrack/devices/Organelle.cpp
+++ b/mec-kontrol/pd/kontrolrack/devices/Organelle.cpp
@@ -2,6 +2,7 @@
 
 #include <osc/OscOutboundPacketStream.h>
 //#include <cmath>
+#include <algorithm>
 
 #include "../../m_pd.h"
 

--- a/mec-kontrol/pd/kontrolrack/dirent_win.cpp
+++ b/mec-kontrol/pd/kontrolrack/dirent_win.cpp
@@ -1,0 +1,109 @@
+#include "dirent_win.h"
+
+#ifdef _WIN32
+
+#include <string>
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+#include <utility>
+
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+static void dirent_init(dirent &d, int type, const std::string &name)
+{
+    d.d_type = type;
+    strncpy(d.d_name, name.c_str(), std::min(sizeof(dirent::d_name) - 1, name.size() + 1));
+    d.d_name[sizeof(dirent::d_name) - 1] = '\0';
+}
+
+int alphasort(const struct dirent **a, const struct dirent **b)
+{
+    return strcmp((*a)->d_name, (*b)->d_name);
+}
+
+static std::wstring toWideString(const std::string &str)
+{
+    std::wstring result;
+    int n = MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, str.c_str(), str.size(), NULL, 0);
+
+    if (n != 0)
+    {
+        wchar_t *w = new wchar_t[n];
+
+        if (MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, str.c_str(), str.size(), w, n) != 0)
+        {
+            result = std::wstring(w, n);
+        }
+
+        delete[] w;
+    }
+
+    return result;
+}
+
+static std::string toUtf8String(const std::wstring &str)
+{
+    std::string result;
+    int n = WideCharToMultiByte(CP_UTF8, 0, str.c_str(), str.size(), NULL, 0, NULL, NULL);
+
+    if (n != 0)
+    {
+        char *c = new char[n];
+
+        if (WideCharToMultiByte(CP_UTF8, 0, str.c_str(), str.size(), c, n, NULL, NULL) != 0)
+        {
+            result = std::string(c, n);
+        }
+
+        delete[] c;
+    }
+
+    return result;
+}
+
+// Limited implementation, without filter support and only recognizing directories.
+int scandir(const char *dirp, struct dirent ***namelist, int(*filter)(const struct dirent *), int(*compar)(const struct dirent **, const struct dirent **))
+{
+    std::wstring directory = toWideString(dirp);
+
+    directory = directory + L"\\*";
+
+    WIN32_FIND_DATAW findFileData;
+    HANDLE hFind = FindFirstFileW(directory.c_str(), &findFileData);
+
+    if (hFind == INVALID_HANDLE_VALUE)
+        return 0;
+
+    std::vector<std::pair<std::string, int> > files;
+
+    do
+    {
+        int type = DT_UNKNOWN;
+
+        if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            type = DT_DIR;
+
+        files.push_back(std::make_pair(toUtf8String(findFileData.cFileName), type));
+    } while (FindNextFileW(hFind, &findFileData));
+
+    FindClose(hFind);
+
+    *namelist = (dirent**)malloc(sizeof(dirent*) * files.size());
+
+    int i = 0;
+    for (std::vector<std::pair<std::string, int> >::iterator itr = files.begin(); itr != files.end(); ++itr)
+    {
+        (*namelist)[i] = (dirent*)malloc(sizeof(dirent));
+        dirent_init(*(*namelist)[i], itr->second, itr->first);
+        ++i;
+    }
+
+    qsort(*namelist, files.size(), sizeof(dirent*), (int(*)(const void*, const void*))compar);
+
+    return files.size();
+}
+
+#endif // _WIN32

--- a/mec-kontrol/pd/kontrolrack/dirent_win.h
+++ b/mec-kontrol/pd/kontrolrack/dirent_win.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <string>
+
+enum
+{
+    DT_UNKNOWN = 0,
+    DT_DIR = 1,
+};
+
+struct dirent
+{
+    int d_type;
+    char d_name[512];
+};
+
+int alphasort(const struct dirent **a, const struct dirent **b);
+int scandir(const char *dirp, struct dirent ***namelist, int(*filter)(const struct dirent *), int(*compar)(const struct dirent **, const struct dirent **));
+
+#endif // _WIN32

--- a/mec-utils/CMakeLists.txt
+++ b/mec-utils/CMakeLists.txt
@@ -13,7 +13,5 @@ include_directories(
 )
 
 add_library(mec-utils SHARED ${MECUTILS_SRC})
-
+set_target_properties(mec-utils PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 target_link_libraries(mec-utils cjson)
-
-


### PR DESCRIPTION
Most of these changes are meant for MSVC, but the dirent_win.h is relevant for MinGW building too (there's no scandir on it).

I verified building and running on MSVC, MinGW and Linux make.