### PR TITLE
Build granularity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
 
 if(WIN32)
     message("windows support limited")
+    set(DISABLE_LIBUSB 1)
+    set(DISABLE_EIGENHARP 1)
+    set(DISABLE_SOUNDPLANELITE 1)
+    set(DISABLE_PUSH2 1)
 endif()
 
 if (APPLE)
@@ -58,7 +62,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/release/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/release/bin)
 
 ############
-if(NOT WIN32)
+if(NOT DISABLE_LIBUSB)
 add_subdirectory(external/libusb libusb)
 endif()
 

--- a/mec-api/CMakeLists.txt
+++ b/mec-api/CMakeLists.txt
@@ -2,10 +2,38 @@
 # MEC library
 project(mec-api)
 
-if (NOT WIN32)
-    set(MECDEVICES_SRC
+if (NOT DISABLE_SOUNDPLANELITE)
+    set(SOUNDPLANELITE_SRC
+            devices/mec_soundplane.cpp
+            devices/mec_soundplane.h
+            )
+
+    add_subdirectory(devices/soundplanelite)
+
+    set(SOUNDPLANELITE_LIB mec-soundplane)
+
+    include_directories("devices/soundplanelite")
+else()
+    add_definitions(-DDISABLE_SOUNDPLANELITE=1)
+endif()
+
+if (NOT DISABLE_EIGENHARP)
+    set(EIGENHARP_SRC
             devices/mec_eigenharp.cpp
             devices/mec_eigenharp.h
+            )
+
+    add_subdirectory(devices/eigenharp)
+
+    set(EIGENHARP_LIB mec-eigenharp)
+
+    include_directories("devices/eigenharp")
+else()
+    add_definitions(-DDISABLE_EIGENHARP=1)
+endif()
+
+if (NOT DISABLE_PUSH2)
+    set(PUSH2_SRC
             devices/mec_push2.cpp
             devices/mec_push2.h
             devices/push2/mec_push2_param.cpp
@@ -14,14 +42,16 @@ if (NOT WIN32)
             devices/push2/mec_push2_device.h
             devices/push2/mec_push2_play.h
             devices/push2/mec_push2_play.cpp
-            devices/mec_soundplane.cpp
-            devices/mec_soundplane.h
             )
 
-    add_subdirectory(devices/eigenharp)
-    add_subdirectory(devices/soundplanelite)
     add_subdirectory(devices/push2)
-endif ()
+
+    set(PUSH2_LIB mec-push2)
+
+    include_directories("devices/push2")
+else()
+    add_definitions(-DDISABLE_PUSH2=1)
+endif()
 
 set(MECAPI_SRC
         mec_api.cpp
@@ -47,12 +77,12 @@ set(MECAPI_SRC
         devices/mec_kontroldevice.cpp
         devices/mec_kontroldevice.h
         ${MECDEVICES_SRC}
+        ${SOUNDPLANELITE_SRC}
+        ${EIGENHARP_SRC}
+        ${PUSH2_SRC}
         )
 
 include_directories(
-        "devices/push2"
-        "devices/eigenharp"
-        "devices/soundplanelite"
         "${PROJECT_SOURCE_DIR}/../mec-utils"
         "${PROJECT_SOURCE_DIR}/../mec-kontrol/api"
         "${PROJECT_SOURCE_DIR}/../external/cJSON"
@@ -62,9 +92,7 @@ include_directories(
 
 add_library(mec-api SHARED ${MECAPI_SRC})
 
-if(NOT WIN32)
-    set(MEC_DEVICE_LIBS mec-eigenharp mec-soundplane mec-push2)
-endif()
+set(MEC_DEVICE_LIBS ${PUSH2_LIB} ${EIGENHARP_LIB} ${SOUNDPLANELITE_LIB})
 
 target_link_libraries(mec-api mec-utils ${MEC_DEVICE_LIBS}  mec-kontrol-api cjson oscpack rtmidi)
 set_target_properties(mec-api PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)

--- a/mec-api/mec_api.cpp
+++ b/mec-api/mec_api.cpp
@@ -5,11 +5,16 @@
 #include "mec_device.h"
 #include "mec_log.h"
 
-#ifndef WIN32
-#include "devices/mec_eigenharp.h"
-#include "devices/mec_soundplane.h"
-#include "devices/mec_push2.h"
+#if !DISABLE_EIGENHARP
+#   include "devices/mec_eigenharp.h"
 #endif
+#if !DISABLE_SOUNDPLANELITE
+#   include "devices/mec_soundplane.h"
+#endif
+#if !DISABLE_PUSH2
+#   include "devices/mec_push2.h"
+#endif
+
 
 #include "devices/mec_mididevice.h"
 #include "devices/mec_osct3d.h"
@@ -273,7 +278,7 @@ void MecApi_Impl::initDevices() {
         return;
     }
 
-#ifndef WIN32
+#if !DISABLE_EIGENHARP
     if (prefs_->exists("eigenharp")) {
         LOG_1("eigenharp initialise ");
         std::shared_ptr<Device> device = std::make_shared<Eigenharp>(*this);
@@ -289,7 +294,9 @@ void MecApi_Impl::initDevices() {
             device->deinit();
         }
     }
+#endif
 
+#if !DISABLE_SOUNDPLANELITE
     if (prefs_->exists("soundplane")) {
         LOG_1("soundplane initialise");
         std::shared_ptr<Device> device = std::make_shared<Soundplane>(*this);
@@ -306,7 +313,9 @@ void MecApi_Impl::initDevices() {
             device->deinit();
         }
     }
+#endif
 
+#if !DISABLE_PUSH2
     if (prefs_->exists("push2")) {
         LOG_1("push2 initialise ");
         std::shared_ptr<Push2> device = std::make_shared<Push2>(*this);

--- a/mec-app/CMakeLists.txt
+++ b/mec-app/CMakeLists.txt
@@ -32,6 +32,10 @@ add_executable(mec-app ${MEC_SRC})
 # target_link_libraries (mec-app mec-api mec-kontrol-api oscpack rtmidi)
 target_link_libraries(mec-app mec-api oscpack rtmidi)
 
+if (UNIX AND NOT APPLE)
+    target_link_libraries(mec-app pthread)
+endif()
+
 if (APPLE)
     target_link_libraries(mec-app "-framework CoreMIDI")
 endif (APPLE)


### PR DESCRIPTION
This pull request adds more granular config options to builds:

* DISABLE_LIBUSB
* DISABLE_SOUNDPLANELITE
* DISABLE_PUSH2
* DISABLE_EIGENHARP

They can be specified when calling cmake (-D...=1) to disable the particular features, these are turned on by default in case of WIN32 builds.