### PR TITLE
Misc changes

### DIFF
--- a/mec-kontrol/api/OSCBroadcaster.h
+++ b/mec-kontrol/api/OSCBroadcaster.h
@@ -59,7 +59,7 @@ protected:
 private:
     struct OscMsg {
         static const int MAX_N_OSC_MSGS = 128;
-        static const int MAX_OSC_MESSAGE_SIZE = 256;
+        static const int MAX_OSC_MESSAGE_SIZE = 512;
         int size_;
         char buffer_[MAX_OSC_MESSAGE_SIZE];
     };

--- a/mec-kontrol/api/OSCReceiver.h
+++ b/mec-kontrol/api/OSCReceiver.h
@@ -101,7 +101,7 @@ private:
 
     struct OscMsg {
         static const int MAX_N_OSC_MSGS = 128;
-        static const int MAX_OSC_MESSAGE_SIZE = 256;
+        static const int MAX_OSC_MESSAGE_SIZE = 512;
         IpEndpointName origin_;
         int size_;
         char buffer_[MAX_OSC_MESSAGE_SIZE];

--- a/mec-kontrol/pd/kontrolmodule/KontrolModule.cpp
+++ b/mec-kontrol/pd/kontrolmodule/KontrolModule.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 static t_class *KontrolModule_class;
 
@@ -12,6 +13,8 @@ typedef struct _KontrolModule {
     t_symbol* rackId;
     t_symbol* moduleId;
     t_symbol* moduleType;
+    char* modId;
+    char* modType;
 } t_KontrolModule;
 
 
@@ -25,27 +28,35 @@ void KontrolModule_loaddefinitions(t_KontrolModule *x, t_symbol *defs);
 // puredata methods implementation - start
 
 void KontrolModule_free(t_KontrolModule *x) {
+    free(x->modId);
+    free(x->modType);
 }
 
-#include <iostream>
+static bool createModule(t_KontrolModule *x) {
+    auto rack = Kontrol::KontrolModel::model()->getLocalRack();
+    if (rack) {
+        auto rackId = rack->id();
+        Kontrol::EntityId moduleId = x->modId;
+        std::string moduleType = x->modType;
+        Kontrol::KontrolModel::model()->createModule(Kontrol::CS_LOCAL, rackId,
+            moduleId, moduleType,
+            moduleType);
+        rack->dumpParameters();
+        x->rackId = gensym(rackId.c_str());
+        x->moduleId = gensym(moduleId.c_str());
+        x->moduleType = gensym(moduleType.c_str());
+        return true;
+    }
+
+    return false;
+}
+
 void *KontrolModule_new(t_symbol *name, t_symbol *type) {
     t_KontrolModule *x = (t_KontrolModule *) pd_new(KontrolModule_class);
     if (name && name->s_name && type && type->s_name) {
-        auto rack = Kontrol::KontrolModel::model()->getLocalRack();
-        if (rack) {
-            auto rackId = rack->id();
-            Kontrol::EntityId moduleId = name->s_name;
-            std::string moduleType = type->s_name;
-            Kontrol::KontrolModel::model()->createModule(Kontrol::CS_LOCAL, rackId,
-                                                         moduleId, moduleType,
-                                                         moduleType);
-            rack->dumpParameters();
-            x->rackId = gensym(rackId.c_str());
-            x->moduleId = gensym(moduleId.c_str());
-            x->moduleType = gensym(moduleType.c_str());
-        } else {
-            post("cannot create %s : No local rack found, KontrolModule needs a KontrolRack instance", name->s_name);
-        }
+        x->modId = strdup(name->s_name);
+        x->modType = strdup(type->s_name);
+        createModule(x);
     }
     return (void *) x;
 }
@@ -65,6 +76,11 @@ void KontrolModule_setup(void) {
 
 void KontrolModule_loaddefinitions(t_KontrolModule *x, t_symbol *defs) {
     if (defs != nullptr && defs->s_name != nullptr && strlen(defs->s_name) > 0) {
+        if (x->moduleId == nullptr) {
+            if (!createModule(x)) {
+                post("cannot create %s : No local rack found, KontrolModule needs a KontrolRack instance", x->modId);
+            }
+        }
         std::string file = std::string(defs->s_name);
         Kontrol::KontrolModel::model()->loadModuleDefinitions(x->rackId->s_name, x->moduleId->s_name, file);
     }


### PR DESCRIPTION
The increase of OSC message size was necessary to be able to use pages with large amount of parameters (15 in our case). I'm ok with making this configurable via a CMake variable, or some graceful handling of this situation should be added instead. Otherwise, the osc message gets truncated at the specified size, and that makes the receiving client get a MalformedMessageException.

The KontrolModule changes protect against a crash which can occur if KontrolRack object gets created after a KontrolModule object. It seems the order of object creation depends on the order of lines in .pd file. In my case, the order swapped in the middle of editing a patch and I was unable to open the patch anymore, because of the crash.