### PR TITLE
/Kontrol/deleteRack

### DIFF
--- a/mec-api/devices/mec_kontroldevice.cpp
+++ b/mec-api/devices/mec_kontroldevice.cpp
@@ -44,6 +44,8 @@ public:
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &,
                   const std::string &, const std::string &) override { ; };
 
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; }
+
     KontrolDevice &this_;
 };
 
@@ -136,8 +138,10 @@ void KontrolDevice::processorRun() {
                         if (!client->isActive()) {
                             LOG_0("KontrolDevice::Process... remove inactive client " << client->host() << " : "
                                                                                       << client->port());
+                            Kontrol::EntityId rackId = Kontrol::Rack::createId(client->host(), client->port());
                             client->stop();
                             clients_.erase(it);
+                            model_->deleteRack(Kontrol::CS_LOCAL, rackId);
                             inactive = true;
                         } else {
                             it++;

--- a/mec-api/devices/mec_push2.h
+++ b/mec-api/devices/mec_push2.h
@@ -64,6 +64,7 @@ public:
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &,
                   const std::string&, const std::string &) override { ; };
 
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; };
 };
 
 class P2_PadMode : Kontrol::KontrolCallback {
@@ -91,6 +92,8 @@ public:
 
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &,
                   const std::string&, const std::string &) override { ; };
+
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; };
 };
 
 enum PushDisplayModes {
@@ -130,6 +133,8 @@ public:
 
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &,
                   const std::string&, const std::string &) override ;
+
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; };
 
     void addDisplayMode(PushDisplayModes mode, std::shared_ptr<P2_DisplayMode>);
     void changeDisplayMode(PushDisplayModes);

--- a/mec-kontrol/api/KontrolModel.cpp
+++ b/mec-kontrol/api/KontrolModel.cpp
@@ -224,6 +224,8 @@ std::shared_ptr<Parameter> KontrolModel::createParam(
 
 void KontrolModel::deleteRack(ChangeSource src, const EntityId &rackId)
 {
+    if (localRack_ && localRack_->id() == rackId)
+        localRack_ = nullptr;
     auto rack = getRack(rackId);
     if (rack)
     {

--- a/mec-kontrol/api/KontrolModel.cpp
+++ b/mec-kontrol/api/KontrolModel.cpp
@@ -222,6 +222,19 @@ std::shared_ptr<Parameter> KontrolModel::createParam(
 }
 
 
+void KontrolModel::deleteRack(ChangeSource src, const EntityId &rackId)
+{
+    auto rack = getRack(rackId);
+    if (rack)
+    {
+        for (auto i : listeners_) {
+            (i.second)->deleteRack(src, *rack);
+        }
+    }
+    racks_.erase(rackId);
+}
+
+
 void KontrolModel::activeModule(ChangeSource src, const EntityId &rackId ,const EntityId &moduleId) {
     auto rack = getRack(rackId);
     auto module = getModule(rack, moduleId);

--- a/mec-kontrol/api/KontrolModel.h
+++ b/mec-kontrol/api/KontrolModel.h
@@ -26,6 +26,8 @@ public:
     virtual void changed(ChangeSource, const Rack &, const Module &, const Parameter &) = 0;
     virtual void resource(ChangeSource, const Rack &, const std::string &, const std::string &) = 0;
 
+    virtual void deleteRack(ChangeSource, const Rack &) = 0;
+
     virtual void activeModule(ChangeSource, const Rack &, const Module &) { ; }
 
     virtual void ping(ChangeSource src, const std::string &host, unsigned port, unsigned keepAlive) { ; }
@@ -114,6 +116,9 @@ public:
                         const EntityId &rackId,
                         const std::string &resType,
                         const std::string &resValue) const;
+
+    void deleteRack(ChangeSource src,
+                    const EntityId &rackId);
 
     void activeModule(ChangeSource src, const EntityId &rackId ,const EntityId &moduleId);
 

--- a/mec-kontrol/api/OSCBroadcaster.cpp
+++ b/mec-kontrol/api/OSCBroadcaster.cpp
@@ -404,5 +404,22 @@ void OSCBroadcaster::resource(ChangeSource src, const Rack &rack, const std::str
     send(ops.Data(), ops.Size());
 }
 
+void OSCBroadcaster::deleteRack(ChangeSource src, const Rack &rack)
+{
+	if (!broadcastChange(src)) return;
+	if (!isActive()) return;
+
+	osc::OutboundPacketStream ops(buffer_, OUTPUT_BUFFER_SIZE);
+
+	ops << osc::BeginBundleImmediate
+		<< osc::BeginMessage("/Kontrol/deleteRack")
+		<< rack.id().c_str();
+
+	ops << osc::EndMessage
+		<< osc::EndBundle;
+
+	send(ops.Data(), ops.Size());
+}
+
 
 } // namespace

--- a/mec-kontrol/api/OSCBroadcaster.cpp
+++ b/mec-kontrol/api/OSCBroadcaster.cpp
@@ -46,6 +46,7 @@ bool OSCBroadcaster::connect(const std::string &host, unsigned port) {
 }
 
 void OSCBroadcaster::stop() {
+    flush();
     running_ = false;
     if (socket_) {
         writer_thread_.join();
@@ -59,12 +60,17 @@ void OSCBroadcaster::stop() {
 void OSCBroadcaster::writePoll() {
     std::unique_lock<std::mutex> lock(write_lock_);
     while (running_) {
-        while (PaUtil_GetRingBufferReadAvailable(&messageQueue_)) {
-            OscMsg msg;
-            PaUtil_ReadRingBuffer(&messageQueue_, &msg, 1);
-            socket_->Send(msg.buffer_, msg.size_);
-        }
+        flush();
         write_cond_.wait_for(lock, std::chrono::milliseconds(POLL_TIMEOUT_MS));
+    }
+}
+
+void OSCBroadcaster::flush()
+{
+    while (PaUtil_GetRingBufferReadAvailable(&messageQueue_)) {
+        OscMsg msg;
+        PaUtil_ReadRingBuffer(&messageQueue_, &msg, 1);
+        socket_->Send(msg.buffer_, msg.size_);
     }
 }
 

--- a/mec-kontrol/api/OSCBroadcaster.h
+++ b/mec-kontrol/api/OSCBroadcaster.h
@@ -32,7 +32,7 @@ public:
     void param(ChangeSource src, const Rack &rack, const Module &module, const Parameter &) override;
     void changed(ChangeSource src, const Rack &rack, const Module &module, const Parameter &p) override;
     void resource(ChangeSource, const Rack &, const std::string &, const std::string &) override;
-
+    void deleteRack(ChangeSource, const Rack &) override;
 
     void ping(ChangeSource src, const std::string &host, unsigned port, unsigned keepAlive) override;
     void assignMidiCC(ChangeSource, const Rack &, const Module &, const Parameter &, unsigned midiCC) override;

--- a/mec-kontrol/api/OSCBroadcaster.h
+++ b/mec-kontrol/api/OSCBroadcaster.h
@@ -57,6 +57,8 @@ protected:
     bool broadcastChange(ChangeSource src);
 
 private:
+    void flush();
+
     struct OscMsg {
         static const int MAX_N_OSC_MSGS = 128;
         static const int MAX_OSC_MESSAGE_SIZE = 256;

--- a/mec-kontrol/api/OSCReceiver.cpp
+++ b/mec-kontrol/api/OSCReceiver.cpp
@@ -131,6 +131,11 @@ public:
 
 //                 std::cout << "received resource " << rackId <<  " : " << resType << " : " << resValue << std::endl;
                 receiver_.createResource(changedSrc, rackId, resType, resValue);
+            } else if (std::strcmp(m.AddressPattern(), "/Kontrol/deleteRack") == 0) {
+                osc::ReceivedMessage::const_iterator arg = m.ArgumentsBegin();
+                const char *rackId = (arg++)->AsString();
+
+                receiver_.deleteRack(changedSrc, rackId);
             } else if (std::strcmp(m.AddressPattern(), "/Kontrol/assignMidiCC") == 0) {
                 osc::ReceivedMessage::const_iterator arg = m.ArgumentsBegin();
                 const char *rackId = (arg++)->AsString();
@@ -279,6 +284,11 @@ void OSCReceiver::createResource(ChangeSource src,
                                  const std::string &resType,
                                  const std::string &resValue) const {
     model_->createResource(src, rackId, resType, resValue);
+}
+
+void OSCReceiver::deleteRack(ChangeSource src, const EntityId & rackId)
+{
+	model_->deleteRack(src, rackId);
 }
 
 void OSCReceiver::ping(ChangeSource src,

--- a/mec-kontrol/api/OSCReceiver.h
+++ b/mec-kontrol/api/OSCReceiver.h
@@ -67,6 +67,9 @@ public:
                         const std::string &resType,
                         const std::string &resValue) const;
 
+    void deleteRack(ChangeSource src,
+                    const EntityId &rackId);
+
     void ping(ChangeSource src, const std::string &host, unsigned port, unsigned keepalive);
 
     void assignMidiCC(ChangeSource src,

--- a/mec-kontrol/pd/kontrolrack/CMakeLists.txt
+++ b/mec-kontrol/pd/kontrolrack/CMakeLists.txt
@@ -11,6 +11,11 @@ set(KONTROL_HOST_SRC
         devices/Organelle.cpp
         )
 
+if (${WIN32})
+    list(APPEND KONTROL_HOST_SRC KontrolWin.cpp)
+else ()
+    list(APPEND KONTROL_HOST_SRC KontrolPosix.cpp)
+endif()
 
 include_directories(
         "${PROJECT_SOURCE_DIR}/.."

--- a/mec-kontrol/pd/kontrolrack/KontrolPosix.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolPosix.cpp
@@ -4,10 +4,7 @@
 
 __attribute__((destructor)) void kontrol_uninit(void)
 {
-	// Delete the local rack on exiting, if there is one.
-	auto localRackId = Kontrol::KontrolModel::model()->localRackId();
-	if (!localRackId.empty())
-		Kontrol::KontrolModel::model()->deleteRack(Kontrol::CS_LOCAL, localRackId);
+    KontrolRack_cleanup();
 }
 
 #endif

--- a/mec-kontrol/pd/kontrolrack/KontrolPosix.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolPosix.cpp
@@ -1,0 +1,13 @@
+#ifndef _WIN32
+
+#include "KontrolRack.h"
+
+__attribute__((destructor)) void kontrol_uninit(void)
+{
+	// Delete the local rack on exiting, if there is one.
+	auto localRackId = Kontrol::KontrolModel::model()->localRackId();
+	if (!localRackId.empty())
+		Kontrol::KontrolModel::model()->deleteRack(Kontrol::CS_LOCAL, localRackId);
+}
+
+#endif

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -42,6 +42,7 @@ public:
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &,
                   const std::string &, const std::string &) override { ; }
 
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; }
 
     void loadModule(Kontrol::ChangeSource, const Kontrol::Rack &,
                     const Kontrol::EntityId &, const std::string &) override;

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -124,6 +124,7 @@ void KontrolRack_tick(t_KontrolRack *x) {
 
 void KontrolRack_free(t_KontrolRack *x) {
     clock_free(x->x_clock);
+    x->model_->deleteRack(Kontrol::CS_LOCAL, x->model_->localRackId());
     x->model_->clearCallbacks();
     if (x->osc_receiver_) x->osc_receiver_->stop();
     x->osc_receiver_.reset();

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -239,6 +239,21 @@ EXTERN void KontrolRack_setup(void) {
 
 }
 
+// Called from OS specific library unload methods.
+void KontrolRack_cleanup(void)
+{
+    auto model = Kontrol::KontrolModel::model();
+    if (model)
+    {
+        // Delete the local rack on exiting, if there is one.
+        auto localRackId = model->localRackId();
+        if (!localRackId.empty())
+        {
+            model->deleteRack(Kontrol::CS_LOCAL, localRackId);
+            model->clearCallbacks(); // Triggers stop() and in turn flushes the deleteRack message.
+        }
+    }
+}
 
 void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol *mod) {
     if (modId == nullptr && modId->s_name == nullptr && strlen(modId->s_name) == 0) {

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -56,3 +56,5 @@ void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol* mod);
 
 void KontrolRack_loadresources(t_KontrolRack *x);
 }
+
+extern void KontrolRack_cleanup(void);

--- a/mec-kontrol/pd/kontrolrack/KontrolWin.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolWin.cpp
@@ -1,0 +1,28 @@
+#ifdef _WIN32
+
+#include "KontrolRack.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+BOOLEAN WINAPI DllMain(
+	IN HINSTANCE dllHandle,
+	IN DWORD     reason,
+	IN LPVOID    reserved)
+{
+	switch (reason)
+	{
+	case DLL_PROCESS_DETACH:
+		{
+			// Delete the local rack on exiting, if there is one.
+			auto localRackId = Kontrol::KontrolModel::model()->localRackId();
+			if (!localRackId.empty())
+				Kontrol::KontrolModel::model()->deleteRack(Kontrol::CS_LOCAL, localRackId);
+			break;
+		}
+	}
+
+	return TRUE;
+}
+
+#endif

--- a/mec-kontrol/pd/kontrolrack/KontrolWin.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolWin.cpp
@@ -6,23 +6,16 @@
 #include <Windows.h>
 
 BOOLEAN WINAPI DllMain(
-	IN HINSTANCE dllHandle,
-	IN DWORD     reason,
-	IN LPVOID    reserved)
+    IN HINSTANCE dllHandle,
+    IN DWORD     reason,
+    IN LPVOID    reserved)
 {
-	switch (reason)
-	{
-	case DLL_PROCESS_DETACH:
-		{
-			// Delete the local rack on exiting, if there is one.
-			auto localRackId = Kontrol::KontrolModel::model()->localRackId();
-			if (!localRackId.empty())
-				Kontrol::KontrolModel::model()->deleteRack(Kontrol::CS_LOCAL, localRackId);
-			break;
-		}
-	}
+    if (reason == DLL_PROCESS_DETACH)
+    {
+        KontrolRack_cleanup();
+    }
 
-	return TRUE;
+    return TRUE;
 }
 
 #endif

--- a/mec-kontrol/pd/kontrolrack/devices/KontrolDevice.cpp
+++ b/mec-kontrol/pd/kontrolrack/devices/KontrolDevice.cpp
@@ -88,6 +88,10 @@ void KontrolDevice::resource(Kontrol::ChangeSource src, const Kontrol::Rack &rac
     if (m != nullptr) m->resource(src, rack, resType, resValue);
 }
 
+void KontrolDevice::deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &)
+{
+}
+
 void KontrolDevice::loadModule(Kontrol::ChangeSource src, const Kontrol::Rack &rack,
                                const Kontrol::EntityId &moduleId, const std::string &modType) {
     auto m = modes_[currentMode_];

--- a/mec-kontrol/pd/kontrolrack/devices/KontrolDevice.h
+++ b/mec-kontrol/pd/kontrolrack/devices/KontrolDevice.h
@@ -49,6 +49,7 @@ public:
     void changed(Kontrol::ChangeSource, const Kontrol::Rack &, const Kontrol::Module &,
                  const Kontrol::Parameter &) override;
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &, const std::string &, const std::string &) override;
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override;
 
     void activeModule(Kontrol::ChangeSource, const Kontrol::Rack &, const Kontrol::Module &) override;
 

--- a/mec-kontrol/pd/kontrolrack/devices/Organelle.cpp
+++ b/mec-kontrol/pd/kontrolrack/devices/Organelle.cpp
@@ -64,6 +64,8 @@ public:
     void resource(Kontrol::ChangeSource, const Kontrol::Rack &, const std::string &,
                   const std::string &) override { ; };
 
+    void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &) override { ; }
+
     void displayPopup(const std::string &text, unsigned time, bool dblline);
 protected:
     Organelle &parent_;

--- a/mec-kontrol/tests/t_kontrol.cpp
+++ b/mec-kontrol/tests/t_kontrol.cpp
@@ -37,6 +37,10 @@ public:
                   const std::string &resType, const std::string &res) override {
         LOG_1("resource >> " << rack.id() << " " << resType << " " << res);
     }
+
+    virtual void deleteRack(Kontrol::ChangeSource, const Kontrol::Rack &rack) override {
+        LOG_1("deleteRack >> " << rack.id());
+    }
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This pull request adds `/Kontrol/deleteRack s "rack_name"` command. It's meant to be used to inform other Kontrol clients about the client exiting, or timing out of the system. The next time the client comes online, the rack it has will get restored via the usual metadata publishing mechanism.

The deleteRack gets sent in the following cases:

1. The client is terminating gracefully (KontrolRack PD object getting deleted, PD or the patch containing KontrolRack gets closed by the user)
2. When mec-app detects timeout, it will send deleteRack to all currently connected clients.
3. If one of the clients (A) terminates another client (B), then A may send deleteRack to mec-app so that waiting for timeout is not necessary for changes to take effect.