### PR TITLE
Single module mode argument

### DIFF
--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -191,6 +191,8 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     } else if (device == "simpleosc") {
         post("KontrolRack: device = %s", device.c_str());
         x->device_ = std::make_shared<SimpleOsc>();
+    } else if (device == "none") {
+        post("KontrolRack: not using a device");
     } else {
         post("KontrolRack: unknown device = %s", device.c_str());
     }
@@ -198,10 +200,10 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     if(x->device_) {
         x->device_->init();
         x->device_->currentRack(x->model_->localRackId());
+        x->model_->addCallback("pd.dev", x->device_);
     }
 
     x->model_->addCallback("pd.send", std::make_shared<PdCallback>(x));
-    x->model_->addCallback("pd.dev", x->device_);
 
     KontrolRack_listen(x, clientport);
     KontrolRack_connect(x, serverport);

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -24,6 +24,7 @@ typedef struct _KontrolRack {
     std::shared_ptr<Kontrol::OSCReceiver> osc_receiver_;
     std::shared_ptr<Kontrol::OSCBroadcaster> osc_broadcaster_;
     t_symbol* active_module_;
+    bool single_module_mode_;
 } t_KontrolRack;
 
 
@@ -56,6 +57,7 @@ void KontrolRack_savesettings(t_KontrolRack *x, t_symbol *settings);
 void KontrolRack_loadpreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_updatepreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol* mod);
+void KontrolRack_singlemodulemode(t_KontrolRack *x, t_floatarg f);
 
 
 


### PR DESCRIPTION
Added 'singlemodulemode' message to KontrolRack.

'singlemodulemode 1' message can be sent to KontrolRack to enable the single module mode, and 'singlemodule 0' to disable it.

The default mode is multi module mode.

Bonus commit to allow having no 'device' instantiation in KontrolRack, when communicating via MEC is enough, and it fixes a crash when a null pointer gets registered for callbacks, in case the x->device_ ends up being nullptr.