### PR TITLE
Kontrol monitoring

### DIFF
--- a/mec-kontrol/api/Parameter.cpp
+++ b/mec-kontrol/api/Parameter.cpp
@@ -135,6 +135,14 @@ ParamValue Parameter::calcFloat(float f) {
     return current_;
 }
 
+ParamValue Parameter::calcMinimum() const {
+    return ParamValue();
+}
+
+ParamValue Parameter::calcMaximum() const {
+    return ParamValue();
+}
+
 ParamValue Parameter::calcMidi(int midi) {
     float f = (float) midi / 127.0f;
     return calcFloat(f);
@@ -223,6 +231,13 @@ ParamValue Parameter_Float::calcFloat(float f) {
     return ParamValue(v);
 }
 
+ParamValue Parameter_Float::calcMinimum() const {
+    return ParamValue(min());
+}
+
+ParamValue Parameter_Float::calcMaximum() const {
+    return ParamValue(max());
+}
 
 float Parameter_Float::asFloat(const ParamValue& v) const {
     float val = v.floatValue();
@@ -297,6 +312,14 @@ ParamValue Parameter_Boolean::calcRelative(float f) {
 
 ParamValue Parameter_Boolean::calcFloat(float f) {
     return ParamValue(f > 0.5f ? 1.0f : 0.0f);
+}
+
+ParamValue Parameter_Boolean::calcMinimum() const {
+    return ParamValue(0.0f);
+}
+
+ParamValue Parameter_Boolean::calcMaximum() const {
+    return ParamValue(1.0f);
 }
 
 ParamValue Parameter_Boolean::calcMidi(int midi) {
@@ -394,6 +417,13 @@ ParamValue Parameter_Int::calcFloat(float f) {
     return ParamValue((float) v);
 }
 
+ParamValue Parameter_Int::calcMinimum() const {
+    return ParamValue(min());
+}
+
+ParamValue Parameter_Int::calcMaximum() const {
+    return ParamValue(max());
+}
 
 float Parameter_Int::asFloat(const ParamValue& v) const {
     float val = v.floatValue();

--- a/mec-kontrol/api/Parameter.h
+++ b/mec-kontrol/api/Parameter.h
@@ -40,6 +40,9 @@ public:
     virtual ParamValue calcFloat(float f);
     virtual ParamValue calcMidi(int midi);
 
+    virtual ParamValue calcMinimum() const;
+    virtual ParamValue calcMaximum() const;
+
     virtual float asFloat (const ParamValue& v) const;
 
     virtual bool valid() { return Entity::valid() && type_ != PT_Invalid; }
@@ -65,6 +68,9 @@ public:
     ParamValue calcRelative(float f) override;
     ParamValue calcMidi(int midi) override;
     ParamValue calcFloat(float f) override;
+
+    ParamValue calcMinimum() const override;
+    ParamValue calcMaximum() const override;
 
     float asFloat(const ParamValue& v) const override;
 
@@ -94,6 +100,9 @@ public:
     ParamValue calcMidi(int midi) override;
     ParamValue calcFloat(float f) override;
 
+    ParamValue calcMinimum() const override;
+    ParamValue calcMaximum() const override;
+
     float asFloat(const ParamValue& v) const override;
 
 protected:
@@ -120,6 +129,9 @@ public:
     ParamValue calcRelative(float f) override;
     ParamValue calcMidi(int midi) override;
     ParamValue calcFloat(float f) override;
+
+    ParamValue calcMinimum() const override;
+    ParamValue calcMaximum() const override;
 
     float asFloat(const ParamValue& v) const override;
 

--- a/mec-kontrol/pd/kontrolrack/CMakeLists.txt
+++ b/mec-kontrol/pd/kontrolrack/CMakeLists.txt
@@ -5,12 +5,19 @@ project(KontrolRack)
 
 set(KONTROL_HOST_SRC
         KontrolRack.cpp
+        KontrolRack.h
+        KontrolMonitor.cpp
+        KontrolMonitor.h
         dirent_win.cpp
         dirent_win.h
         devices/KontrolDevice.cpp
+        devices/KontrolDevice.h
         devices/Organelle.cpp
+        devices/Organelle.h
         devices/Bela.cpp
+        devices/Bela.h
         devices/SimpleOsc.cpp
+        devices/SimpleOsc.h
         )
 
 if (${WIN32})

--- a/mec-kontrol/pd/kontrolrack/KontrolMonitor.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolMonitor.cpp
@@ -1,0 +1,113 @@
+#include "KontrolMonitor.h"
+#include <KontrolModel.h>
+
+#include "../m_pd.h"
+
+#include <string>
+
+static t_class *KontrolMonitor_class;
+
+struct t_KontrolMonitor {
+    t_object x_obj;
+    t_symbol *symbol;
+
+    char *rack;
+    char *module;
+    char *param;
+};
+
+t_KontrolMonitor * KontrolMonitor_new(t_symbol *symbol, const Kontrol::Rack &rack, const Kontrol::Module &module, const Kontrol::Parameter &param) {
+    t_KontrolMonitor *x = (t_KontrolMonitor*)pd_new(KontrolMonitor_class);
+
+    x->symbol = symbol;
+    x->rack = strdup(rack.id().c_str());
+    x->module = strdup(module.id().c_str());
+    x->param = strdup(param.id().c_str());
+
+    pd_bind(&x->x_obj.ob_pd, x->symbol);
+
+    std::string symbolString = std::string(x->symbol->s_name);
+
+    t_pd *range = gensym((symbolString + "-range").c_str())->s_thing;
+    if (range) {
+        t_atom args[2];
+        SETFLOAT(&args[0], param.calcMinimum().floatValue());
+        SETFLOAT(&args[1], param.calcMaximum().floatValue());
+        pd_forwardmess(range, 2, args);
+    }
+
+    pd_bind(&x->x_obj.ob_pd, gensym((symbolString + "-load").c_str()));
+
+    return x;
+}
+
+void KontrolMonitor_free(t_KontrolMonitor *x) {
+    std::string loadSymbol = std::string(x->symbol->s_name) + "-load";
+    pd_unbind(&x->x_obj.ob_pd, x->symbol);
+    pd_unbind(&x->x_obj.ob_pd, gensym(loadSymbol.c_str()));
+    free(x->rack);
+    free(x->module);
+    free(x->param);
+
+    pd_free((t_pd*)&x->x_obj);
+}
+
+static void KontrolMonitor_float(t_KontrolMonitor *x, t_floatarg f) {
+    Kontrol::KontrolModel::model()->changeParam(Kontrol::CS_LOCAL, x->rack, x->module, x->param, f);
+}
+
+static void KontrolMonitor_bang(t_KontrolMonitor *x) {
+    auto model = Kontrol::KontrolModel::model();
+    auto rack = model->getRack(x->rack);
+    auto module = model->getModule(rack, x->module);
+    auto param = model->getParam(module, x->param);
+
+    if (!param)
+        return;
+
+    float value = param->current().floatValue();
+    float min = param->calcMinimum().floatValue();
+    float max = param->calcMaximum().floatValue();
+
+    t_pd *sendsym = x->symbol->s_thing;
+    if (sendsym) {
+        t_atom arg;
+        SETFLOAT(&arg, value);
+        pd_forwardmess(sendsym, 1, &arg);
+    }
+
+    std::string symbolString = x->symbol->s_name;
+    t_pd *range = gensym((symbolString + "-range").c_str())->s_thing;
+    if (range) {
+        t_atom args[2];
+        SETFLOAT(&args[0], min);
+        SETFLOAT(&args[1], max);
+        pd_forwardmess(range, 2, args);
+    }
+
+    t_pd *name = gensym((symbolString + "-name").c_str())->s_thing;
+    if (name) {
+        t_atom arg;
+
+        std::string displayName = param->displayName();
+        for (auto &c : displayName) {
+            if (c == ' ')
+                c = '_';
+        }
+
+        SETSYMBOL(&arg, gensym(displayName.c_str()));
+        pd_forwardmess(name, 1, &arg);
+    }
+}
+
+void KontrolMonitor_setup(void) {
+    KontrolMonitor_class = class_new(gensym("KontrolMonitor"),
+        NULL,
+        NULL,
+        sizeof(t_KontrolMonitor),
+        CLASS_DEFAULT,
+        A_NULL);
+
+    class_addfloat(KontrolMonitor_class, (t_method)KontrolMonitor_float);
+    class_addbang(KontrolMonitor_class, (t_method)KontrolMonitor_bang);
+}

--- a/mec-kontrol/pd/kontrolrack/KontrolMonitor.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolMonitor.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../m_pd.h"
+
+struct t_KontrolMonitor;
+
+namespace Kontrol {
+    class Rack;
+    class Module;
+    class Parameter;
+}
+
+t_KontrolMonitor * KontrolMonitor_new(t_symbol *symbol, const Kontrol::Rack &rack, const Kontrol::Module &module, const Kontrol::Parameter &param);
+void KontrolMonitor_free(t_KontrolMonitor *obj);
+void KontrolMonitor_setup(void);

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -191,6 +191,8 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     } else if (device == "simpleosc") {
         post("KontrolRack: device = %s", device.c_str());
         x->device_ = std::make_shared<SimpleOsc>();
+    } else if (device == "none") {
+        post("KontrolRack: not using a device");
     } else {
         post("KontrolRack: unknown device = %s", device.c_str());
     }
@@ -198,10 +200,10 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     if(x->device_) {
         x->device_->init();
         x->device_->currentRack(x->model_->localRackId());
+        x->model_->addCallback("pd.dev", x->device_);
     }
 
     x->model_->addCallback("pd.send", std::make_shared<PdCallback>(x));
-    x->model_->addCallback("pd.dev", x->device_);
 
     KontrolRack_listen(x, clientport);
     KontrolRack_connect(x, serverport);

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -182,6 +182,7 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     x->active_module_ = nullptr;
     x->osc_receiver_ = nullptr;
     x->single_module_mode_ = false;
+    x->monitor_enable_ = false;
 
     x->pollCount_ = 0;
     x->model_ = Kontrol::KontrolModel::model();
@@ -307,6 +308,10 @@ EXTERN void KontrolRack_setup(void) {
 
     class_addmethod(KontrolRack_class,
                     (t_method) KontrolRack_singlemodulemode, gensym("singlemodulemode"),
+                    A_DEFFLOAT, A_NULL);
+
+    class_addmethod(KontrolRack_class,
+                    (t_method) KontrolRack_monitorenable, gensym("monitorenable"),
                     A_DEFFLOAT, A_NULL);
 
     KontrolMonitor_setup();
@@ -477,7 +482,13 @@ void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol *mod) {
 void KontrolRack_singlemodulemode(t_KontrolRack *x, t_floatarg f) {
     bool enable = f >= 0.5f;
     post("KontrolRack: single module mode -> %d", enable);
-    x->single_module_mode_ = f >= 0.5f;
+    x->single_module_mode_ = enable;
+}
+
+void KontrolRack_monitorenable(t_KontrolRack *x, t_floatarg f) {
+    bool enable = f >= 0.5f;
+    post("KontrolRack: Enable control monitoring: %d", enable);
+    x->monitor_enable_ = enable;
 }
 
 void KontrolRack_connect(t_KontrolRack *x, t_floatarg f) {
@@ -690,7 +701,7 @@ void PdCallback::param(Kontrol::ChangeSource src,
 
     t_symbol *symbol = gensym(getParamSymbol(x_->single_module_mode_, module, param).c_str());
 
-    if (x_->param_monitors_->find(symbol) == x_->param_monitors_->end()) {
+    if (x_->monitor_enable_ && x_->param_monitors_->find(symbol) == x_->param_monitors_->end()) {
         t_KontrolMonitor *x = (t_KontrolMonitor*)KontrolMonitor_new(symbol, rack, module, param);
 
         (*x_->param_monitors_)[symbol] = x;

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -26,6 +26,7 @@ typedef struct _KontrolRack {
     std::shared_ptr<Kontrol::OSCBroadcaster> osc_broadcaster_;
     t_symbol* active_module_;
     bool single_module_mode_;
+    bool monitor_enable_; // Enable monitoring control changes within PD, and forwarding to KontrolModel.
 
     std::unordered_map<t_symbol *, t_KontrolMonitor*> *param_monitors_;
 } t_KontrolRack;
@@ -61,7 +62,7 @@ void KontrolRack_loadpreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_updatepreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol* mod);
 void KontrolRack_singlemodulemode(t_KontrolRack *x, t_floatarg f);
-
+void KontrolRack_monitorenable(t_KontrolRack *x, t_floatarg f);
 
 
 void KontrolRack_loadresources(t_KontrolRack *x);

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -24,6 +24,7 @@ typedef struct _KontrolRack {
     std::shared_ptr<Kontrol::OSCReceiver> osc_receiver_;
     std::shared_ptr<Kontrol::OSCBroadcaster> osc_broadcaster_;
     t_symbol* active_module_;
+    bool single_module_mode_;
 } t_KontrolRack;
 
 
@@ -56,6 +57,7 @@ void KontrolRack_savesettings(t_KontrolRack *x, t_symbol *settings);
 void KontrolRack_loadpreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_updatepreset(t_KontrolRack *x, t_symbol *preset);
 void KontrolRack_loadmodule(t_KontrolRack *x, t_symbol *modId, t_symbol* mod);
+void KontrolRack_singlemodulemode(t_KontrolRack *x, t_floatarg f);
 
 
 

--- a/mec-kontrol/pd/kontrolrack/KontrolRack.h
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <unordered_map>
 
+struct t_KontrolMonitor;
 
 typedef struct _KontrolRack {
     t_object x_obj;
@@ -25,6 +26,8 @@ typedef struct _KontrolRack {
     std::shared_ptr<Kontrol::OSCBroadcaster> osc_broadcaster_;
     t_symbol* active_module_;
     bool single_module_mode_;
+
+    std::unordered_map<t_symbol *, t_KontrolMonitor*> *param_monitors_;
 } t_KontrolRack;
 
 


### PR DESCRIPTION
This pull request is built on top of #11, so it should be merged first.

The changes here add monitoring of the parameter changes within Pure Data, and forwards them to the KontrolModel, so it can be shared with all the clients.

This feature is disabled by default and 'monitorenable 1' message can be sent to KontrolRack to enable it.