### PR TITLE
Add 'kontrol' device option to KontrolRack

### DIFF
--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -198,6 +198,9 @@ void *KontrolRack_new(t_symbol* sym, int argc, t_atom *argv) {
     } else if (device == "midi") {
         post("KontrolRack: device = %s", device.c_str());
         x->device_ = std::make_shared<MidiControl>();
+    } else if (device == "kontrol") {
+        post("KontrolRack: device = %s", device.c_str());
+        x->device_ = std::make_shared<KontrolDevice>();
     } else if (device == "none") {
         post("KontrolRack: not using a device");
     } else {


### PR DESCRIPTION
Adding KontrolDevice instantiation in KontrolRack object, when 'kontrol' is given to the object constructor.