### PR TITLE
Don't fire PD events for value changes detected by KontrolMonitor

### DIFF
--- a/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
+++ b/mec-kontrol/pd/kontrolrack/KontrolRack.cpp
@@ -660,10 +660,13 @@ static std::string getParamSymbol(bool singleModuleMode, const Kontrol::Module &
 }
 
 //-----------------------
-void PdCallback::changed(Kontrol::ChangeSource,
+void PdCallback::changed(Kontrol::ChangeSource src,
                          const Kontrol::Rack &rack,
                          const Kontrol::Module &module,
                          const Kontrol::Parameter &param) {
+
+    if (src == Kontrol::CS_LOCAL)
+        return;
 
     auto prack = Kontrol::KontrolModel::model()->getLocalRack();
     if (prack == nullptr || prack->id() != rack.id()) return;


### PR DESCRIPTION
This change suppress firing the same message back to PD, if it came from PD itself.