### PR TITLE
Added DISABLE_RPATH_OVERRIDE variable to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,17 +52,17 @@ elseif (UNIX)
     endif ()
 endif (APPLE)
 
-
-## setup rpath for linux and macos
-set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-if (NOT APPLE)
+if (NOT DISABLE_RPATH_OVERRIDE)
+  ## setup rpath for linux and macos
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+  if (NOT APPLE)
     set(CMAKE_INSTALL_RPATH "$ORIGIN/:$ORIGIN/../lib")
-else()
-  set(CMAKE_INSTALL_NAME_DIR "@rpath")
-  set(CMAKE_INSTALL_RPATH "@executable_path/../lib;@loader_path")
-  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR TRUE)
+  else()
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
+    set(CMAKE_INSTALL_RPATH "@executable_path/../lib;@loader_path")
+    set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR TRUE)
+  endif()
 endif()
-
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/release/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/release/bin)


### PR DESCRIPTION
This was needed when building Blokas distribution of MEC, so that all the 3rd party .so's could be bundled with MEC package, and to avoid conflicts with the ones from apt repositories containing different versions. When rpath flag is used during building, LD_LIBRARY_PATH is ignored by the OS, so it was necessary to avoid specifying rpath, so that a small wrapper shell script could be written to set the LD_LIBRARY_PATH env var to /usr/lib/MEC before starting mec itself. (see https://github.com/BlokasLabs/mec-pkg/blob/master/debian/usr/bin/mec)

I briefly explored trying to build MEC with what's available on apt repositories, but there were conflicts with different versions used, so MEC was not building without further modifications, so decided that building the 3rd party libs from MEC repository and putting them into its own folder was the safest way to go.