### PR TITLE
Added /Kontrol/publishStart and /Kontrol/publishRackFinished

### DIFF
--- a/mec-kontrol/api/KontrolModel.cpp
+++ b/mec-kontrol/api/KontrolModel.cpp
@@ -20,6 +20,9 @@ KontrolModel::KontrolModel() {
 }
 
 void KontrolModel::publishMetaData() const {
+    for (auto i : listeners_) {
+        (i.second)->publishStart(CS_LOCAL, 1);
+    }
     publishMetaData(localRack_);
 }
 
@@ -33,6 +36,9 @@ void KontrolModel::publishMetaData(const std::shared_ptr<Rack> &rack) const {
     }
     for (const auto &p : modules) {
         if (p != nullptr) publishMetaData(rack, p);
+    }
+    for (auto i : listeners_) {
+        (i.second)->publishRackFinished(CS_LOCAL, *rack);
     }
 }
 
@@ -302,6 +308,20 @@ void KontrolModel::assignMidiCC(ChangeSource src, const EntityId &rackId, const 
     }
 }
 
+void KontrolModel::publishStart(ChangeSource src, unsigned numRacks) {
+    for (auto i : listeners_) {
+        (i.second)->publishStart(src, numRacks);
+    }
+}
+
+void KontrolModel::publishRackFinished(ChangeSource src, const EntityId &rackId) {
+    for (auto i : listeners_) {
+        auto rack = getRack(rackId);
+        if (rack == nullptr)
+            return;
+        (i.second)->publishRackFinished(src, *rack);
+    }
+}
 
 void KontrolModel::unassignMidiCC(ChangeSource src, const EntityId &rackId, const EntityId &moduleId,
                                   const EntityId &paramId, unsigned midiCC) {

--- a/mec-kontrol/api/KontrolModel.h
+++ b/mec-kontrol/api/KontrolModel.h
@@ -39,6 +39,12 @@ public:
     virtual void assignModulation(ChangeSource, const Rack &, const Module &, const Parameter &, unsigned bus) { ; }
     virtual void unassignModulation(ChangeSource, const Rack &, const Module &, const Parameter &, unsigned bus) { ; }
 
+    // Sent just before publishing all the information to other clients.
+    virtual void publishStart(ChangeSource, unsigned numRacks) { ; }
+
+    // Sent after completing each rack. The client should expect to receive the number of racks provided via the publishStart message.
+    virtual void publishRackFinished(ChangeSource, const Rack &) { ; }
+
     virtual void updatePreset(ChangeSource, const Rack &, std::string preset) { ; }
 
     virtual void applyPreset(ChangeSource, const Rack &, std::string preset) { ; }
@@ -151,6 +157,8 @@ public:
                         const EntityId &paramId,
                         unsigned bus);
 
+    void publishStart(ChangeSource src, unsigned numRacks);
+    void publishRackFinished(ChangeSource src, const EntityId &rackId);
 
     void updatePreset(ChangeSource src,
                       const EntityId &rackId,

--- a/mec-kontrol/api/OSCBroadcaster.h
+++ b/mec-kontrol/api/OSCBroadcaster.h
@@ -48,6 +48,9 @@ public:
     void midiLearn(ChangeSource src, bool b) override;
     void modulationLearn(ChangeSource src, bool b) override;
 
+    void publishStart(ChangeSource, unsigned numRacks) override;
+    void publishRackFinished(ChangeSource, const Rack &) override;
+
     bool isThisHost(const std::string &host, unsigned port) { return host == host_ && port == port_; }
 
     bool isActive();

--- a/mec-kontrol/api/OSCReceiver.cpp
+++ b/mec-kontrol/api/OSCReceiver.cpp
@@ -169,6 +169,14 @@ public:
                 const char *paramId = (arg++)->AsString();
                 unsigned bus = (unsigned) (arg++)->AsInt32();
                 receiver_.unassignModulation(changedSrc, rackId, moduleId, paramId, bus);
+            } else if (std::strcmp(m.AddressPattern(), "/Kontrol/publishStart") == 0) {
+                osc::ReceivedMessage::const_iterator arg = m.ArgumentsBegin();
+                unsigned numRacks = (unsigned)arg->AsInt32();
+                receiver_.publishStart(changedSrc, numRacks);
+            } else if (std::strcmp(m.AddressPattern(), "/Kontrol/publishRackFinished") == 0) {
+                osc::ReceivedMessage::const_iterator arg = m.ArgumentsBegin();
+                const char *rackId = arg->AsString();
+                receiver_.publishRackFinished(changedSrc, rackId);
             } else if (std::strcmp(m.AddressPattern(), "/Kontrol/updatePreset") == 0) {
                 osc::ReceivedMessage::const_iterator arg = m.ArgumentsBegin();
                 const char *rackId = (arg++)->AsString();
@@ -351,6 +359,13 @@ void OSCReceiver::unassignModulation(ChangeSource src, const EntityId &rackId, c
     model_->unassignModulation(src, rackId, moduleId, paramId, bus);
 }
 
+void OSCReceiver::publishStart(ChangeSource src, unsigned numRacks) {
+    model_->publishStart(src, numRacks);
+}
+
+void OSCReceiver::publishRackFinished(ChangeSource src, const EntityId & rackId) {
+    model_->publishRackFinished(src, rackId);
+}
 
 void OSCReceiver::updatePreset(ChangeSource src, const EntityId &rackId, std::string preset) {
     model_->updatePreset(src, rackId, preset);

--- a/mec-kontrol/api/OSCReceiver.h
+++ b/mec-kontrol/api/OSCReceiver.h
@@ -99,6 +99,8 @@ public:
                             const EntityId &paramId,
                             unsigned bus);
 
+    void publishStart(ChangeSource src, unsigned numRacks);
+    void publishRackFinished(ChangeSource src, const EntityId &rackId);
 
     void updatePreset(ChangeSource src,
                       const EntityId &rackId,


### PR DESCRIPTION
2 new osc messages added which help other clients know how many racks to expect and when the client has all the data:

1. /Kontrol/publishStart i num_racks
    * Before publishing any data to a client, inform how many racks will be published. Then the client knows to expect num_racks count of the below message.
2. /Kontrol/publishRackFinished s "rack_name"
    * Informs the client that the data publishing on rack "rack_name" is complete. Upon receiving num_racks count of this message, the client may know that it has everything.

Clients who don't need this may just ignore the new messages.