### PR TITLE
send resource and preset when client connects to Kontrol

### DIFF
--- a/mec-kontrol/api/OSCBroadcaster.cpp
+++ b/mec-kontrol/api/OSCBroadcaster.cpp
@@ -156,6 +156,12 @@ void OSCBroadcaster::ping(ChangeSource src, const std::string &host, unsigned po
                     if (rackId != r->id()) {
                         std::cerr << " publishing meta data to " << rackId << " for " << r->id() << std::endl;
                         rack(CS_LOCAL, *r);
+                        for (const auto &resType:r->getResourceTypes()) {
+                            for (const auto &res : r->getResources(resType)) {
+                                resource(CS_LOCAL, *r, resType, res);
+                            }
+                        }
+                        loadPreset(CS_LOCAL, *r, r->currentPreset());
                         for (const auto &m : r->getModules()) {
                             module(CS_LOCAL, *r, *m);
                             for (const auto &p :  m->getParams()) {


### PR DESCRIPTION
This is needed for an OSC client using /Kontrol/* messages to control ORAC. 
Without this commit, a client is not able to trigger MEC to send resource and preset to client.
I know I can also use oscdisplay messages to control ORAC, but the documentation used Kontrol message and it is what I am using now in my client implementation.