### PR TITLE
fix missing header

### DIFF
--- a/mec-kontrol/api/KontrolModel.cpp
+++ b/mec-kontrol/api/KontrolModel.cpp
@@ -1,5 +1,6 @@
 #include "KontrolModel.h"
 #include <mec_prefs.h>
+#include <stdexcept>
 
 namespace Kontrol {
 


### PR DESCRIPTION
This change was necessary in order to build with `clang` (on Ubuntu Linux x86).