### PR TITLE
Sb test soundplane velocity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 
 project(mec)
 

--- a/mec-api/devices/mec_soundplane.cpp
+++ b/mec-api/devices/mec_soundplane.cpp
@@ -30,8 +30,8 @@ public:
 class SoundplaneHandler : public ::SPLiteCallback {
 public:
     // these are used to adjust velocity, they are highly dependent on hardware, to get the right feel, experiment!
-    static constexpr float V_COUNT = 2; // samples to use for velocity , lets try 2-N,  (was 4)
-    static constexpr float V_SCALE_AMT = 8.0f; // scale, to help V_COUNT pressures, quickly = max vel.  (was 4.0)
+    static constexpr float V_COUNT = 4; // samples to use for velocity , lets try 2-N,  (was 4)
+    static constexpr float V_SCALE_AMT = 4.0f; // scale, to help V_COUNT pressures, quickly = max vel.  (was 4.0)
     static constexpr float V_CURVE_AMT = 4.0f; // a pow scaling, 1.0 = linear, < 1.0 = more sensitive,  > 1.0 = less sensitive (more firm pressure)  (was 4.0)
 
     SoundplaneHandler(Preferences &p, 

--- a/mec-api/devices/mec_soundplane.cpp
+++ b/mec-api/devices/mec_soundplane.cpp
@@ -129,24 +129,29 @@ public:
                 if (!voice && stealVoices_) {
                     // no available voices, steal?
                     Voices::Voice *stolen = voices_.oldestActiveVoice();
-                    callback_.touchOff(stolen->i_, stolen->note_, stolen->x_, stolen->y_, 0.0f);
+                    // only send touchOff if the stolen voice actually sounded (touchOn was sent)
+                    if (stolen->state_ == Voices::Voice::ACTIVE) {
+                        callback_.touchOff(stolen->i_, stolen->note_, stolen->x_, stolen->y_, 0.0f);
+                    }
                     voices_.stopVoice(stolen);
 
                     voice = voices_.startVoice(touch);
                 }
+            }
 
-                if (voice) {
-                    // LOG_1("calculated velocity" << touch << " ch " << voice->i_ << " vel " << voice->v_);
-                    callback_.touchOn(voice->i_, mn, mx, my, voice->v_); //v_ = calculated velocity
-                    // callback_.touchOn(voice->i_, mn, mx, my, mz); //use z after velCount samples, ignore velocity
-                    voice->note_ = mn;
-                    voice->x_ = mx;
-                    voice->y_ = my;
-                    voice->z_ = mz;
-                    voice->t_ = t;
+            if (voice) {
+                if (voice->state_ == Voices::Voice::PENDING) {
+                    // feed the velocity detector; defer touchOn until it has
+                    // enough pressure frames to measure the onset velocity.
+                    voices_.addPressure(voice, mz);
+                    if (voice->state_ == Voices::Voice::ACTIVE) {
+                        // LOG_1("calculated velocity" << touch << " ch " << voice->i_ << " vel " << voice->v_);
+                        callback_.touchOn(voice->i_, mn, mx, my, voice->v_); //v_ = calculated velocity
+                    }
+                    // don't send to callbacks until we have the minimum pressures for velocity
+                } else {
+                    callback_.touchContinue(voice->i_, mn, mx, my, mz);
                 }
-            } else {
-        		callback_.touchContinue(voice->i_, mn, mx, my, mz);
                 voice->note_ = mn;
                 voice->x_ = mx;
                 voice->y_ = my;
@@ -157,11 +162,11 @@ public:
         } else {
             if (voice) {
                 //LOG_1("stop voice for " << touch << " ch " << voice->i_ );
-                //msg.type_ = MecMsg::TOUCH_OFF;
-                //msg.data_.touch_.touchId_ = voice->i_;
-                //msg.data_.touch_.z_ = 0.0;
-                //queue_.addToQueue(msg);
-                callback_.touchOff(voice->i_, mn, mx, my, mz);
+                // only send touchOff if touchOn was sent (voice reached ACTIVE);
+                // a PENDING voice never sounded, so just release it.
+                if (voice->state_ == Voices::Voice::ACTIVE) {
+                    callback_.touchOff(voice->i_, mn, mx, my, mz);
+                }
                 voices_.stopVoice(voice);
             }
             stolenTouches_.erase(touch);

--- a/mec-api/devices/mec_soundplane.cpp
+++ b/mec-api/devices/mec_soundplane.cpp
@@ -4,6 +4,7 @@
 #include "mec_log.h"
 #include "../mec_voice.h"
 #include <set>
+// #include "../mec-utils/mec_log.h"
 
 namespace mec {
 
@@ -28,12 +29,22 @@ public:
 ////////////////////////////////////////////////
 class SoundplaneHandler : public ::SPLiteCallback {
 public:
+    // these are used to adjust velocity, they are highly dependent on hardware, to get the right feel, experiment!
+    static constexpr float V_COUNT = 2; // samples to use for velocity , lets try 2-N,  (was 4)
+    static constexpr float V_SCALE_AMT = 8.0f; // scale, to help V_COUNT pressures, quickly = max vel.  (was 4.0)
+    static constexpr float V_CURVE_AMT = 4.0f; // a pow scaling, 1.0 = linear, < 1.0 = more sensitive,  > 1.0 = less sensitive (more firm pressure)  (was 4.0)
+
     SoundplaneHandler(Preferences &p, 
 		    ICallback& cb)
             : prefs_(p),
               callback_(cb),
               valid_(true),
-              voices_(static_cast<unsigned>(p.getInt("voices", 15))),
+              voices_(
+                static_cast<unsigned>(p.getInt("voices", 15)),
+                static_cast<unsigned>(p.getInt("vel_count", V_COUNT)),
+                static_cast<float>(p.getDouble("vel_curve", V_CURVE_AMT)),
+                static_cast<float>(p.getDouble("vel_scale", V_SCALE_AMT))
+              ),
               stealVoices_(p.getBool("steal voices", true)) {
         if (valid_) {
             LOG_0("SoundplaneHandler enabling for mecapi");
@@ -125,7 +136,9 @@ public:
                 }
 
                 if (voice) {
+                    // LOG_1("calculated velocity" << touch << " ch " << voice->i_ << " vel " << voice->v_);
                     callback_.touchOn(voice->i_, mn, mx, my, voice->v_); //v_ = calculated velocity
+                    // callback_.touchOn(voice->i_, mn, mx, my, mz); //use z after velCount samples, ignore velocity
                     voice->note_ = mn;
                     voice->x_ = mx;
                     voice->y_ = my;

--- a/mec-api/mec_voice.h
+++ b/mec-api/mec_voice.h
@@ -2,8 +2,9 @@
 #define MEC_VOICES_H_
 
 #include <math.h>
-#include <vector>
+
 #include <list>
+#include <vector>
 
 #include "mec_log.h"
 
@@ -11,20 +12,14 @@ namespace mec {
 
 class Voices {
 public:
-    static constexpr float NUM_VOICES    = 15;
-    static constexpr float V_SCALE_AMT  = 4.0f;
-    static constexpr float V_CURVE_AMT  = 4.0f;
-    static constexpr float V_COUNT      = 4;
+    static constexpr float NUM_VOICES = 15;
+    static constexpr float V_SCALE_AMT = 4.0f;
+    static constexpr float V_CURVE_AMT = 4.0f;
+    static constexpr float V_COUNT = 4;
 
-    Voices( unsigned voiceCount = NUM_VOICES, 
-            unsigned velCount = V_COUNT,
-            float velCurve = V_CURVE_AMT,
-            float velScale = V_SCALE_AMT)
-            :   maxVoices_(voiceCount), 
-                velCount_(velCount),
-                velCurve_(velCurve),
-                velScale_(velScale)
-                 {
+    Voices(unsigned voiceCount = NUM_VOICES, unsigned velCount = V_COUNT, float velCurve = V_CURVE_AMT,
+           float velScale = V_SCALE_AMT)
+        : maxVoices_(voiceCount), velCount_(velCount), velCurve_(velCurve), velScale_(velScale) {
         voices_.resize(maxVoices_);
         for (int i = 0; i < maxVoices_; i++) {
             voices_[i].i_ = i;
@@ -32,7 +27,6 @@ public:
             voices_[i].id_ = -1;
             freeVoices_.push_back(&voices_[i]);
         }
-
     };
 
     virtual ~Voices() {};
@@ -49,29 +43,28 @@ public:
         unsigned long long t_;
         enum {
             INACTIVE,
-            PENDING, // velocity
+            PENDING,  // velocity
             ACTIVE,
         } state_;
 
-        //velocity, taken from velocity detector
+        // velocity, taken from velocity detector
         struct {
             unsigned vcount_;
             float sumx_, sumy_, sumxy_, sumxsq_, x_;
-            float scale_, curve_; // comes from config
+            float scale_, curve_;  // comes from config
             float raw_;
         } vel_;
     };
 
-    Voice *voiceId(unsigned id) {
+    Voice* voiceId(unsigned id) {
         for (int i = 0; i < maxVoices_; i++) {
-            if (voices_[i].id_ == id)
-                return &voices_[i];
+            if (voices_[i].id_ == id) return &voices_[i];
         }
         return NULL;
     }
 
-    Voice *startVoice(unsigned id) {
-        Voice *voice;
+    Voice* startVoice(unsigned id) {
+        Voice* voice;
         if (freeVoices_.size() > 0) {
             voice = freeVoices_.front();
             freeVoices_.pop_front();
@@ -80,6 +73,7 @@ public:
             // if you wish to steal it
             return NULL;
         }
+
         voice->id_ = id;
         voice->state_ = Voice::PENDING;
         voice->v_ = 0;
@@ -87,58 +81,57 @@ public:
         voice->vel_.scale_ = velScale_;
         voice->vel_.curve_ = velCurve_;
         voice->vel_.vcount_ = 0;
-        voice->vel_.sumx_ = voice->vel_.sumy_ = voice->vel_.sumxy_ = voice->vel_.sumxsq_ = 0.0;
-        voice->vel_.x_ = 0.0;
+        voice->vel_.sumx_ = 0.0;
+        voice->vel_.sumy_ = 0.0;
+        voice->vel_.sumxy_ = 0.0;
+        voice->vel_.sumxsq_ = 0.0;
 
-        voice->vel_.sumx_ += voice->vel_.x_;
-        voice->vel_.sumxsq_ += voice->vel_.x_ * voice->vel_.x_;
-        voice->vel_.x_++;
-
-        voice->vel_.sumx_ += voice->vel_.x_;
-        voice->vel_.sumxsq_ += voice->vel_.x_ * voice->vel_.x_;
-        voice->vel_.x_++;
-
+        // First actual pressure sample will use x = 1
+        voice->vel_.x_ = 1.0;
 
         usedVoices_.push_back(voice);
         return voice;
     }
+    void addPressure(Voice* voice, float p) {
+        if (voice->state_ != Voice::PENDING) { return; }
 
-    void addPressure(Voice *voice, float p) {
-        if (voice->state_ == Voice::PENDING) {
+        if (voice->vel_.vcount_ < velCount_) {
+            voice->vel_.sumx_ += voice->vel_.x_;
+            voice->vel_.sumy_ += p;
+            voice->vel_.sumxy_ += (voice->vel_.x_ * p);
+            voice->vel_.sumxsq_ += (voice->vel_.x_ * voice->vel_.x_);
 
+            voice->vel_.vcount_++;
+            voice->vel_.x_++;
 
-            if (voice->vel_.vcount_ < velCount_) {
-                voice->vel_.sumx_ += voice->vel_.x_;
-                voice->vel_.sumy_ += p;
-                voice->vel_.sumxy_ += (voice->vel_.x_ * p);
-                voice->vel_.sumxsq_ += (voice->vel_.x_ * voice->vel_.x_);
-                voice->vel_.vcount_++;
-                voice->vel_.x_++;
-                return;
-                // if (p <= 1.0) {
-                //     return;
-                // }
-                // else max pressure, so consider 'complete'
-            }
-
-            voice->state_ = Voice::ACTIVE;
-            voice->vel_.raw_ = voice->vel_.scale_ *
-                               (voice->vel_.x_ * voice->vel_.sumxy_ - (voice->vel_.sumx_ * voice->vel_.sumy_))
-                               / (voice->vel_.x_ * voice->vel_.sumxsq_ - (voice->vel_.sumx_ * voice->vel_.sumx_));
-            voice->v_ = static_cast<float>(1.0f - pow((double) (1.0f - voice->vel_.raw_), (double) (voice->vel_.curve_)));
-
-            // LOG_1("vel detector : " << voice->id_);
-            // LOG_1("raw : " << voice->vel_.raw_ << " v " << voice->v_);
-            // LOG_1("x  " << voice->vel_.x_);
-            // LOG_1("sumxy " <<voice->vel_.sumxy_ << " sumxsq " << voice->vel_.sumxsq_);
-            // LOG_1("sumx  " << voice->vel_.sumx_ << " sumy " << voice->vel_.sumy_ );
-
-            if (voice->v_ > 1.0) voice->v_ = 1.0;
-            if (voice->v_ < 0.01) voice->v_ = 0.01;
+            // Compute velocity immediately when enough samples have been collected.
+            if (voice->vel_.vcount_ < velCount_) { return; }
         }
+
+        voice->state_ = Voice::ACTIVE;
+
+        const double n = static_cast<double>(voice->vel_.vcount_);
+        const double numerator = n * voice->vel_.sumxy_ - voice->vel_.sumx_ * voice->vel_.sumy_;
+        const double denominator = n * voice->vel_.sumxsq_ - voice->vel_.sumx_ * voice->vel_.sumx_;
+
+        if (fabs(denominator) < 1e-12) {
+            voice->vel_.raw_ = 0.0;
+        } else {
+            voice->vel_.raw_ = voice->vel_.scale_ * numerator / denominator;
+        }
+
+        // Protect the curve calculation from invalid values.
+        if (voice->vel_.raw_ < 0.0)
+            voice->vel_.raw_ = 0.0;
+        else if (voice->vel_.raw_ > 1.0)
+            voice->vel_.raw_ = 1.0;
+
+        voice->v_ = static_cast<float>(1.0 - pow(1.0 - voice->vel_.raw_, voice->vel_.curve_));
+        if (voice->v_ > 1.0f) voice->v_ = 1.0f;
+        if (voice->v_ < 0.01f) voice->v_ = 0.01f;
     }
 
-    void stopVoice(Voice *voice) {
+    void stopVoice(Voice* voice) {
         if (!voice) return;
         usedVoices_.remove(voice);
         voice->id_ = -1;
@@ -151,20 +144,18 @@ public:
         freeVoices_.push_back(voice);
     }
 
-    Voice *oldestActiveVoice() {
-        return usedVoices_.front();
-    }
+    Voice* oldestActiveVoice() { return usedVoices_.front(); }
 
 
 private:
     std::vector<Voice> voices_;
-    std::list<Voice *> freeVoices_;
-    std::list<Voice *> usedVoices_;
+    std::list<Voice*> freeVoices_;
+    std::list<Voice*> usedVoices_;
     unsigned maxVoices_;
     unsigned velCount_;
     float velScale_;
     float velCurve_;
 };
-}
+}  // namespace mec
 
-#endif //MEC_VOICES_H_
+#endif  // MEC_VOICES_H_


### PR DESCRIPTION
Based on Technobear's [sb_test](https://github.com/TheTechnobear/MEC/tree/sb_test) branch, which updated velocity detection for the SoundPlane following the approach used for the Eigenharp. This PR adds to that fix by borrowing more of the Eigenharp voice code to use `addPressure` to accumulate velocity briefly before setting the note to the Active state.

Tested with my Soundplane, works great 👍 